### PR TITLE
Update short_date function to avoid potential crash on musl if year > 9999

### DIFF
--- a/src/misc.c
+++ b/src/misc.c
@@ -153,7 +153,6 @@ const char *long_date(time_t clock)
 const char *short_date(time_t ts, char *buf)
 {
 	struct tm *t = gmtime(&ts);
-	char *timestr;
 	static char retbuf[128];
 
 	if (!buf)
@@ -163,12 +162,9 @@ const char *short_date(time_t ts, char *buf)
 	if (!t)
 		return NULL;
 
-	timestr = asctime(t);
-	if (!timestr)
+	if (!strftime(buf, 128, "%a %b %d %H:%M:%S %Y", t))
 		return NULL;
 
-	strlcpy(buf, timestr, 128);
-	stripcrlf(buf);
 	return buf;
 }
 


### PR DESCRIPTION
The asctime() function is undefined when called with a year of >9999 (as it would generate output longer than the 26 byte buffer) according to POSIX
This only appears triggerable through sending dodgy data through S2S commands, however does cause the musl-based ircds to crash when running on a mixed musl/glibc network.